### PR TITLE
No longer pin versions to travis might run successfully.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,12 +1,8 @@
 [buildout]
 develop = .
 parts = test
-extends = http://grok.zope.org/releaseinfo/1.5.5/versions.cfg
 allow-picked-versions = true
-versions = versions
-
-[versions]
-lxml = 2.2.6
+show-picked-versions = true
 
 [test]
 recipe = zc.recipe.testrunner


### PR DESCRIPTION
grok.zope.org is (at least currently) not available.