### PR TITLE
WIP: Only unindex broken relations on objectmodified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ CHANGES
   ``CHANGES.rst``.
   [thet]
 
+- Only remove broken references on update
+  see https://github.com/plone/Products.CMFPlone/issues/2384
+  [tomgross]
+
 
 0.7 (2015-03-13)
 ================

--- a/src/z3c/relationfield/event.py
+++ b/src/z3c/relationfield/event.py
@@ -71,7 +71,8 @@ def updateRelations(obj, event):
     # remove previous relations coming from id (now have been overwritten)
     # have to activate query here with list() before unindexing them so we don't
     # get errors involving buckets changing size
-    rels = list(catalog.findRelations({'from_id': obj_id}))
+    rels = [rel for rel in catalog.findRelations({'from_id': obj_id})
+            if rel.isBroken()]
     for rel in rels:
         catalog.unindex(rel)
 


### PR DESCRIPTION
This fixes https://github.com/plone/Products.CMFPlone/issues/2384 but might have other side effects.

@icemac @thet @pbauer mind to review?