### PR TITLE
Allows third party software to define which indexes are installed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Breaking changes:
 
 New features:
 
-- addresses #4, allows third party software to define which indexes are used.
+- Adresses `Still uses BTrees wrongly, screws up people changing Interfaces <https://github.com/zopefoundation/z3c.relationfield/issues/4>`_, allows third party software to define which indexes are used.
   [jensens]
 
 Bug fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 CHANGES
 *******
 
-0.7.2 (unreleased)
+0.8.0 (unreleased)
 ==================
 
 Breaking changes:
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- addresses #4, allows third party software to define which indexes are used.
+  [jensens]
 
 Bug fixes:
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = (
 
 setup(
     name='z3c.relationfield',
-    version='0.7.2.dev0',
+    version='0.8.0.dev0',
     description="A relation field framework for Zope 3.",
     long_description=long_description,
     classifiers=[

--- a/src/z3c/relationfield/README.rst
+++ b/src/z3c/relationfield/README.rst
@@ -881,5 +881,7 @@ Setting up a releation catalog
 This package provides a RelationCatalog initialized with a set of indexes commonly useful for queries on RelationValue objects.
 The default indexes are `from_id`, `to_id`, `from_attribute`, `from_interfaces_flattened` and `to_interfaces_flattened`.
 
-However, sometimes it is needed to define custom indexes.
-The `zc.relationfield.index.RelationCatalog` class can be initialized with a list of dicts with keys `name` and `kwargs` to be passed to RelationCatalog to be passed to the catalogs `addValueIndex` method.
+Sometimes it is needed to define custom indexes or use less than the default ones.
+The `zc.relationfield.index.RelationCatalog` class can be initialized with a list of dicts with keys `element` and `kwargs` to be passed to RelationCatalog `addValueIndex` method.
+As `element` in general the attribute on the `IRelationValue` like `IRelationValue['from_id']` is expected.
+However, if theres a subclass of `IRelationValue` is used with additional fields, those fields can be added here as indexes.

--- a/src/z3c/relationfield/README.rst
+++ b/src/z3c/relationfield/README.rst
@@ -874,3 +874,12 @@ It's pointing to the nonexistent path:
 
   >>> root['e'].rel.to_path
   'nonexistent'
+
+Setting up a releation catalog
+==============================
+
+This package provides a RelationCatalog initialized with a set of indexes commonly useful for queries on RelationValue objects.
+The default indexes are `from_id`, `to_id`, `from_attribute`, `from_interfaces_flattened` and `to_interfaces_flattened`.
+
+However, sometimes it is needed to define custom indexes.
+The `zc.relationfield.index.RelationCatalog` class can be initialized with a list of dicts with keys `name` and `kwargs` to be passed to RelationCatalog to be passed to the catalogs `addValueIndex` method.

--- a/src/z3c/relationfield/README.rst
+++ b/src/z3c/relationfield/README.rst
@@ -331,7 +331,7 @@ Let's ask the catalog about the relation from ``b`` to ``a``:
 
   >>> l = sorted(catalog.findRelations({'to_id': intids.getId(root['a'])}))
   >>> l
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
 We look at this relation object again. We indeed go the right one:
 
@@ -369,7 +369,7 @@ interface ``IItem``:
   ...   'from_attribute': 'rel',
   ...   'from_interfaces_flattened': IItem,
   ...   'to_interfaces_flattened': IItem}))
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
 There are no relations stored for another attribute:
 
@@ -416,7 +416,7 @@ We currently have a relation from ``b`` to ``a``:
 .. code-block:: python
 
   >>> sorted(catalog.findRelations({'to_id': intids.getId(root['a'])}))
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
 We can change the relation to point at a new object ``c``:
 
@@ -438,7 +438,7 @@ We should find now a single relation from ``b`` to ``c``:
 .. code-block:: python
 
   >>> sorted(catalog.findRelations({'to_id': c_id}))
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
 The relation to ``a`` should now be gone:
 
@@ -456,12 +456,12 @@ the ObjectModifiedEvent.
   >>> from z3c.relationfield.event import _setRelation
   >>> _setRelation(root['b'], 'my-fancy-relation', rel_to_a)
   >>> sorted(catalog.findRelations({'to_id': intids.getId(root['a'])}))
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
   >>> notify(ObjectModifiedEvent(root['b']))
   >>> rel = sorted(catalog.findRelations({'to_id': intids.getId(root['a'])}))
   >>> rel
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
   >>> catalog.unindex(rel[0])
 
@@ -473,7 +473,7 @@ We have a relation from ``b`` to ``c`` right now:
 .. code-block:: python
 
   >>> sorted(catalog.findRelations({'to_id': c_id}))
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
 We can clean up an existing relation from ``b`` to ``c`` by setting it
 to ``None``:
@@ -505,7 +505,7 @@ Let's reestablish the removed relation:
   >>> notify(ObjectModifiedEvent(root['b']))
 
   >>> sorted(catalog.findRelations({'to_id': c_id}))
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
 
 Copying an object with relations
@@ -583,7 +583,7 @@ We have a relation from ``b`` to ``c`` right now:
 .. code-block:: python
 
   >>> sorted(catalog.findRelations({'to_id': c_id}))
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
 We have no broken relations:
 
@@ -647,7 +647,7 @@ We can however find it by searching for relations that have a
 .. code-block:: python
 
   >>> sorted(catalog.findRelations({'to_id': None}))
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
 A broken relation isn't equal to ``None`` (this was a bug):
 
@@ -699,7 +699,7 @@ We can query for this relation now:
 
   >>> l = sorted(catalog.findRelations({'to_id': some_object_id}))
   >>> l
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
 RelationList
 ============
@@ -805,7 +805,7 @@ We can see the real relation object now:
 .. code-block:: python
 
   >>> root['d'].rel
-  <RelationValue object at ...>
+  <...RelationValue object at ...>
 
 The relation will also now show up in the catalog:
 
@@ -834,7 +834,7 @@ Again we can see the real relation object when we look at it:
 .. code-block:: python
 
   >>> root['multi_temp'].rel
-  [<RelationValue object at ...>]
+  [<...RelationValue object at ...>]
 
 And we will now see this new relation appear in the catalog:
 

--- a/src/z3c/relationfield/index.py
+++ b/src/z3c/relationfield/index.py
@@ -54,7 +54,7 @@ class RelationCatalog(Catalog):
     def __init__(self, indexes=DEFAULT_INDEXES):
         """Initialize the catalog with indexes.
 
-        Uses defaults if not special configuration was passed.
+        Uses defaults if no special configuration was passed.
         """
         Catalog.__init__(self, dump, load)
         for index in indexes:

--- a/src/z3c/relationfield/index.py
+++ b/src/z3c/relationfield/index.py
@@ -5,6 +5,35 @@ from zope.intid.interfaces import IIntIds
 
 import BTrees
 
+DEFAULT_INDEXES = [
+    {
+        'name': 'from_id',
+    },
+    {
+        'name': 'to_id',
+    },
+    {
+        'name': 'from_attribute',
+        'kwargs': {
+            'btree': BTrees.family32.OI,
+        },
+    },
+    {
+        'name': 'from_interfaces_flattened',
+        'kwargs': {
+            'btree': BTrees.family32.OI,
+            'multiple': True,
+        },
+    },
+    {
+        'name': 'to_interfaces_flattened',
+        'kwargs': {
+            'btree': BTrees.family32.OI,
+            'multiple': True,
+        },
+    },
+]
+
 
 def dump(obj, catalog, cache):
     intids = cache.get('intids')
@@ -22,15 +51,14 @@ def load(token, catalog, cache):
 
 class RelationCatalog(Catalog):
 
-    def __init__(self):
+    def __init__(self, indexes=DEFAULT_INDEXES):
+        """initialize the catalog with indexes.with
+
+        Uses defaults if not special configuration was passed.was
+        """
         Catalog.__init__(self, dump, load)
-        self.addValueIndex(IRelationValue['from_id'])
-        self.addValueIndex(IRelationValue['to_id'])
-        self.addValueIndex(IRelationValue['from_attribute'],
-                           btree=BTrees.family32.OI)
-        self.addValueIndex(IRelationValue['from_interfaces_flattened'],
-                           multiple=True,
-                           btree=BTrees.family32.OI)
-        self.addValueIndex(IRelationValue['to_interfaces_flattened'],
-                           multiple=True,
-                           btree=BTrees.family32.OI)
+        for index in indexes:
+            self.addValueIndex(
+                IRelationValue[index['name']],
+                **index.get('kwargs', {})
+            )

--- a/src/z3c/relationfield/index.py
+++ b/src/z3c/relationfield/index.py
@@ -7,26 +7,26 @@ import BTrees
 
 DEFAULT_INDEXES = [
     {
-        'name': 'from_id',
+        'element': IRelationValue['from_id'],
     },
     {
-        'name': 'to_id',
+        'element': IRelationValue['to_id'],
     },
     {
-        'name': 'from_attribute',
+        'element': IRelationValue['from_attribute'],
         'kwargs': {
             'btree': BTrees.family32.OI,
         },
     },
     {
-        'name': 'from_interfaces_flattened',
+        'element': IRelationValue['from_interfaces_flattened'],
         'kwargs': {
             'btree': BTrees.family32.OI,
             'multiple': True,
         },
     },
     {
-        'name': 'to_interfaces_flattened',
+        'element': IRelationValue['to_interfaces_flattened'],
         'kwargs': {
             'btree': BTrees.family32.OI,
             'multiple': True,
@@ -58,7 +58,4 @@ class RelationCatalog(Catalog):
         """
         Catalog.__init__(self, dump, load)
         for index in indexes:
-            self.addValueIndex(
-                IRelationValue[index['name']],
-                **index.get('kwargs', {})
-            )
+            self.addValueIndex(index['element'], **index.get('kwargs', {}))

--- a/src/z3c/relationfield/index.py
+++ b/src/z3c/relationfield/index.py
@@ -52,9 +52,9 @@ def load(token, catalog, cache):
 class RelationCatalog(Catalog):
 
     def __init__(self, indexes=DEFAULT_INDEXES):
-        """initialize the catalog with indexes.with
+        """Initialize the catalog with indexes.
 
-        Uses defaults if not special configuration was passed.was
+        Uses defaults if not special configuration was passed.
         """
         Catalog.__init__(self, dump, load)
         for index in indexes:


### PR DESCRIPTION
Adresses #4 - allows i.e. plone.app.relationfield to not install index for interface querying, because this is not used in Plone. Also avoids for Plone to have broken interface classes in the index after Interfaces were removed. 

This commit does not change the default behavior of this package, it just allows third party users to configure it.