### PR TITLE
Fix DeprecationWarnings in tests.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix DeprecationWarnings in ``tests.py``.
+  [jensens]
 
 
 0.7.1 (2018-11-08)

--- a/src/z3c/relationfield/tests.py
+++ b/src/z3c/relationfield/tests.py
@@ -8,8 +8,8 @@ from z3c.relationfield.testing import (
 )
 from z3c.relationfield import event
 from z3c.relationfield import RelationList, Relation
-from zope.component.interfaces import ObjectEvent
-from zope.component.interfaces import ComponentLookupError
+from zope.interface.interfaces import ObjectEvent
+from zope.interface.interfaces import ComponentLookupError
 
 
 class FieldTests(TestCase):
@@ -18,7 +18,7 @@ class FieldTests(TestCase):
 
     def test_list_value_type(self):
         f = RelationList(title=u"Test")
-        self.failUnless(isinstance(f.value_type, Relation))
+        self.assertTrue(isinstance(f.value_type, Relation))
 
 
 class EventTests(TestCase):


### PR DESCRIPTION
There were some imports from former places and a failUnless which I corrected here to the actual way to do it.