### PR TITLE
Consider RelationValue without source as broken.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ CHANGES
 1.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Consider RelationValue without source as broken.
+  [ksuess]
 
 
 1.0 (2023-02-22)

--- a/src/z3c/relationfield/relation.py
+++ b/src/z3c/relationfield/relation.py
@@ -102,7 +102,7 @@ class RelationValue(Persistent):
         self.to_id = None
 
     def isBroken(self):
-        return self.to_id is None
+        return self.to_id is None or self.from_object is None
 
 
 @implementer(ITemporaryRelationValue)


### PR DESCRIPTION
Deleting a source of a 'isReferencing' RelationValue leaves this instead of removing it from catalog. As long as this is not fixed, this relation should be considered as broken.